### PR TITLE
Tests/aws amplify login

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,14 +1,12 @@
 import 'cypress-testing-library/add-commands'
+import Amplify, { Auth } from 'aws-amplify'
+import aws_exports from '../../src/aws-exports'
+Amplify.configure(aws_exports)
 
 Cypress.Commands.add('login', () => {
-  cy.get('#email')
-    .type('stefan.franzen@addq.se')
-    .should('have.value', 'stefan.franzen@addq.se')
-  cy.get('#password')
-    .type('ADDQbmc123!')
-    .should('have.value', 'ADDQbmc123!')
-  cy.get('[data-testid="loginSubmitButton"]').click()
-  cy.contains('You are now logged in..', { timeout: 10000 })
+  return Auth.signIn('stefan.franzen@addq.se', 'ADDQbmc123!').catch(err =>
+    console.log('An error occured when authenticating using AWS Amplify: ', err)
+  )
 })
 
 Cypress.Commands.add('logout', () => {

--- a/cypress/tests/e2e/details.js
+++ b/cypress/tests/e2e/details.js
@@ -1,6 +1,5 @@
 describe('Testing the details', function() {
   beforeEach(function() {
-    cy.visit('/')
     cy.login()
   })
 

--- a/cypress/tests/e2e/navbar.js
+++ b/cypress/tests/e2e/navbar.js
@@ -1,6 +1,5 @@
 describe('Testing the navbar', function() {
   beforeEach(function() {
-    cy.visit('/')
     cy.login()
     cy.visit('/notfound')
     cy.contains('404')

--- a/cypress/tests/integration/createItem.js
+++ b/cypress/tests/integration/createItem.js
@@ -1,6 +1,5 @@
 describe('Testing creating items', () => {
   before(() => {
-    cy.visit('/')
     cy.login()
   })
 

--- a/src/aws-exports.js
+++ b/src/aws-exports.js
@@ -1,0 +1,25 @@
+import config from './config'
+
+export default {
+  Auth: {
+    mandatorySignIn: false,
+    region: config.cognito.REGION,
+    userPoolId: config.cognito.USER_POOL_ID,
+    identityPoolId: config.cognito.IDENTITY_POOL_ID,
+    userPoolWebClientId: config.cognito.APP_CLIENT_ID,
+  },
+  Storage: {
+    region: config.s3.REGION,
+    bucket: config.s3.BUCKET,
+    identityPoolId: config.cognito.IDENTITY_POOL_ID,
+  },
+  API: {
+    endpoints: [
+      {
+        name: 'bmc-items',
+        endpoint: config.apiGateway.URL,
+        region: config.apiGateway.REGION,
+      },
+    ],
+  },
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,31 +5,8 @@ import './index.css'
 import App from './App'
 import * as serviceWorker from './serviceWorker'
 import Amplify from 'aws-amplify'
-import config from './config'
-
-Amplify.configure({
-  Auth: {
-    mandatorySignIn: false,
-    region: config.cognito.REGION,
-    userPoolId: config.cognito.USER_POOL_ID,
-    identityPoolId: config.cognito.IDENTITY_POOL_ID,
-    userPoolWebClientId: config.cognito.APP_CLIENT_ID,
-  },
-  Storage: {
-    region: config.s3.REGION,
-    bucket: config.s3.BUCKET,
-    identityPoolId: config.cognito.IDENTITY_POOL_ID,
-  },
-  API: {
-    endpoints: [
-      {
-        name: 'bmc-items',
-        endpoint: config.apiGateway.URL,
-        region: config.apiGateway.REGION,
-      },
-    ],
-  },
-})
+import aws_exports from './aws-exports'
+Amplify.configure(aws_exports)
 
 ReactDOM.render(
   <Router>


### PR DESCRIPTION
This updates the `cy.login` custom command and uses aws-amplify to login instead of logging in using the gui, which also makes a few `cy.visit('/)` unnecessary in some tests, so I removed those.

I also moved the aws amplify configuration object from `index.js` into a separate module (`aws-exports.js`, to be able to share it between the tests and the application code, instead of duplicating the configuration in two places.