### PR TITLE
Details/select items

### DIFF
--- a/cypress/tests/e2e/details.js
+++ b/cypress/tests/e2e/details.js
@@ -133,4 +133,39 @@ describe('Testing the details', function() {
 
     cy.contains(inputHeader)
   })
+
+  it.only('can select a specific item', function() {
+    cy.visit('/item/create')
+
+    const inputHeader = `random: ${Math.random() * 999}`
+    cy.getByTestId('createItemInputHeader')
+      .type(inputHeader)
+      .should('have.value', inputHeader)
+
+    const inputText = 'A new item'
+    cy.getByTestId('createItemInputText')
+      .type(inputText)
+      .should('have.value', inputText)
+
+    cy.server()
+    cy.route('POST', '**/prod/bmc-items/create*').as('createRequest')
+    cy.getByText('Create').click()
+
+    cy.wait('@createRequest')
+
+    cy.visit('/details/value-propositions')
+
+    cy.contains(inputHeader).click()
+
+    cy.getByTestId('details-readform-header').should('have.text', inputHeader)
+    cy.getByTestId('details-readform-text').should('have.text', inputText)
+
+    cy.route('GET', '**prod/bmc-items/list*').as('getUpdatedCanvasData')
+    cy.getByText('Edit').click()
+
+    cy.route('DELETE', '**/prod/bmc-items/delete*').as('deleteRequest')
+    cy.getByText('Delete').click()
+
+    cy.wait('@getUpdatedCanvasData')
+  })
 })

--- a/cypress/tests/e2e/details.js
+++ b/cypress/tests/e2e/details.js
@@ -117,6 +117,10 @@ describe('Testing the details', function() {
     })
 
     cy.contains(inputHeader).should('not.be.visible')
+
+    cy.getByTestId('details-list-item')
+      .first()
+      .should('have.class', 'active')
   })
 
   it('should have a list item', function() {

--- a/cypress/tests/e2e/details.js
+++ b/cypress/tests/e2e/details.js
@@ -134,7 +134,7 @@ describe('Testing the details', function() {
     cy.contains(inputHeader)
   })
 
-  it.only('can select a specific item', function() {
+  it('can select a specific item', function() {
     cy.visit('/item/create')
 
     const inputHeader = `random: ${Math.random() * 999}`

--- a/cypress/tests/e2e/details.js
+++ b/cypress/tests/e2e/details.js
@@ -82,6 +82,7 @@ describe('Testing the details', function() {
   })
 
   it('can delete an item', function() {
+    // prepare testdata
     cy.visit('/item/create')
 
     const inputHeader = `random: ${Math.random() * 999}`
@@ -100,6 +101,7 @@ describe('Testing the details', function() {
 
     cy.wait('@createRequest')
 
+    // test starts
     cy.route('GET', '**prod/bmc-items/list*').as('getUpdatedCanvasData')
     cy.visit('/details/value-propositions')
 
@@ -142,6 +144,7 @@ describe('Testing the details', function() {
   })
 
   it('can select a specific item', function() {
+    // prepare testdata
     cy.visit('/item/create')
 
     const inputHeader = `random: ${Math.random() * 999}`
@@ -160,6 +163,7 @@ describe('Testing the details', function() {
 
     cy.wait('@createRequest')
 
+    // test starts
     cy.visit('/details/value-propositions')
 
     cy.contains(inputHeader).click()
@@ -168,6 +172,88 @@ describe('Testing the details', function() {
     cy.getByTestId('details-readform-text').should('have.text', inputText)
     cy.getByTestId('details-list').within(() => {
       cy.get('.active').contains(inputHeader)
+    })
+  })
+
+  it('can change selected item back and forth', function() {
+    // prepare testdata
+    // item 1
+    cy.visit('/item/create')
+
+    const firstItemHeader = `first item: ${Math.random() * 999}`
+    cy.getByTestId('createItemInputHeader')
+      .type(firstItemHeader)
+      .should('have.value', firstItemHeader)
+
+    const firstItemText = 'A new item'
+    cy.getByTestId('createItemInputText')
+      .type(firstItemText)
+      .should('have.value', firstItemText)
+
+    cy.server()
+    cy.route('POST', '**/prod/bmc-items/create*').as('firstItem')
+    cy.getByText('Create').click()
+
+    cy.wait('@firstItem')
+
+    // item 2
+    cy.visit('/item/create')
+
+    const secondItemHeader = `second item: ${Math.random() * 999}`
+    cy.getByTestId('createItemInputHeader')
+      .type(secondItemHeader)
+      .should('have.value', secondItemHeader)
+
+    const secondItemText = 'A new item'
+    cy.getByTestId('createItemInputText')
+      .type(secondItemText)
+      .should('have.value', secondItemText)
+
+    cy.route('POST', '**/prod/bmc-items/create*').as('secondItem')
+    cy.getByText('Create').click()
+
+    cy.wait('@secondItem')
+
+    // test starts
+    cy.visit('/details/value-propositions')
+
+    // click first created item
+    cy.contains(firstItemHeader).click()
+
+    cy.getByTestId('details-readform-header').should('have.text', firstItemHeader)
+    cy.getByTestId('details-readform-text').should('have.text', firstItemText)
+    cy.getByTestId('details-list').within(() => {
+      cy.get('.active').contains(firstItemHeader)
+    })
+
+    cy.get('@firstItem').then(http => {
+      cy.url().should('include', encodeURI(http.response.body.BlockUuid))
+    })
+
+    // click second created item
+    cy.contains(secondItemHeader).click()
+
+    cy.getByTestId('details-readform-header').should('have.text', secondItemHeader)
+    cy.getByTestId('details-readform-text').should('have.text', secondItemText)
+    cy.getByTestId('details-list').within(() => {
+      cy.get('.active').contains(secondItemHeader)
+    })
+
+    cy.get('@secondItem').then(http => {
+      cy.url().should('include', encodeURI(http.response.body.BlockUuid))
+    })
+
+    // click first created item
+    cy.contains(firstItemHeader).click()
+
+    cy.getByTestId('details-readform-header').should('have.text', firstItemHeader)
+    cy.getByTestId('details-readform-text').should('have.text', firstItemText)
+    cy.getByTestId('details-list').within(() => {
+      cy.get('.active').contains(firstItemHeader)
+    })
+
+    cy.get('@firstItem').then(http => {
+      cy.url().should('include', encodeURI(http.response.body.BlockUuid))
     })
   })
 })

--- a/cypress/tests/e2e/details.js
+++ b/cypress/tests/e2e/details.js
@@ -84,6 +84,11 @@ describe('Testing the details', function() {
   it('can delete an item', function() {
     cy.visit('/item/create')
 
+    const inputHeader = `random: ${Math.random() * 999}`
+    cy.getByTestId('createItemInputHeader')
+      .type(inputHeader)
+      .should('have.value', inputHeader)
+
     const inputText = 'A new item'
     cy.getByTestId('createItemInputText')
       .type(inputText)

--- a/cypress/tests/e2e/details.js
+++ b/cypress/tests/e2e/details.js
@@ -166,13 +166,8 @@ describe('Testing the details', function() {
 
     cy.getByTestId('details-readform-header').should('have.text', inputHeader)
     cy.getByTestId('details-readform-text').should('have.text', inputText)
-
-    cy.route('GET', '**prod/bmc-items/list*').as('getUpdatedCanvasData')
-    cy.getByText('Edit').click()
-
-    cy.route('DELETE', '**/prod/bmc-items/delete*').as('deleteRequest')
-    cy.getByText('Delete').click()
-
-    cy.wait('@getUpdatedCanvasData')
+    cy.getByTestId('details-list').within(() => {
+      cy.get('.active').contains(inputHeader)
+    })
   })
 })

--- a/cypress/tests/e2e/details.js
+++ b/cypress/tests/e2e/details.js
@@ -100,19 +100,21 @@ describe('Testing the details', function() {
 
     cy.wait('@createRequest')
 
-    cy.visit('/details/value-propositions')
-
     cy.route('GET', '**prod/bmc-items/list*').as('getUpdatedCanvasData')
-    cy.getByText('Edit').click()
+    cy.visit('/details/value-propositions')
 
     cy.wait('@getUpdatedCanvasData')
 
+    cy.getByText(inputHeader).click()
+    cy.getByText('Edit').click()
     cy.route('DELETE', '**/prod/bmc-items/delete*').as('deleteRequest')
     cy.getByText('Delete').click()
 
     cy.wait('@deleteRequest').then(response => {
       expect(response.status).to.eq(200)
     })
+
+    cy.contains(inputHeader).should('not.be.visible')
   })
 
   it('should have a list item', function() {

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -20,6 +20,7 @@ export default ({ props }) => (
     <AppliedRoute exact path="/horizontal" component={Canvas} props={props} />
     <AppliedRoute exact path="/item/create" component={Create} props={props} />
     <AppliedRoute exact path="/details/:blockType" component={Details} props={props} />
+    <AppliedRoute exact path="/details/:blockType/:blockUuid" component={Details} props={props} />
     <AppliedRoute exact path="/create" component={Create} props={props} />
     <Route component={NotFound} />
   </Switch>

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -234,7 +234,7 @@ export default function Details(props) {
 
     if (block.items[0] !== undefined) {
       return (
-        <div className="details-list">
+        <div className="details-list" data-testid="details-list">
           <ListGroup>{list}</ListGroup>
         </div>
       )

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -36,6 +36,7 @@ export default function Details(props) {
       header: currentBlock.items[card].ItemHeader,
       text: currentBlock.items[card].ItemText,
     })
+    setWriteMode(false)
   }
 
   const getCurrentBlockFromUrl = () => {

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -9,6 +9,7 @@ import { API } from 'aws-amplify'
 export default function Details(props) {
   const [writeMode, setWriteMode] = useState(false)
   const [card, setCard] = useState({
+    blockUuid: '',
     header: '',
     text: '',
   })
@@ -21,11 +22,26 @@ export default function Details(props) {
     setCard({ ...card, text: event.target.value })
   }
 
+  const handleItemChange = event => {
+    event.preventDefault()
+    const href = event.target.getAttribute('href')
+    const selectedItemBlockUuid = href.slice(href.lastIndexOf('/') + 1)
+    const currentBlock = getCurrentBlockFromUrl()
+    const card = currentBlock.items.findIndex(item => {
+      return item.BlockUuid === selectedItemBlockUuid
+    })
+    setCard({
+      blockUuid: currentBlock.items[card].BlockUuid,
+      header: currentBlock.items[card].ItemHeader,
+      text: currentBlock.items[card].ItemText,
+    })
+  }
+
   const getCurrentBlockFromUrl = () => {
     const emptyBlock = {
       block: '',
       blockDescription: '',
-      items: [{ ItemHeader: '', ItemText: '' }],
+      items: [{ ItemHeader: '', ItemText: '', BlockUuid: '' }],
     }
 
     const foundBlock = props.listResponse.find(({ block }) => {
@@ -48,11 +64,15 @@ export default function Details(props) {
   }, [])
 
   useEffect(() => {
-    setCard({
-      ...card,
-      header: getCurrentBlockFromUrl().items[0].ItemHeader,
-      text: getCurrentBlockFromUrl().items[0].ItemText,
-    })
+    if (card.blockUuid === '') {
+      const currentBlock = getCurrentBlockFromUrl()
+      setCard({
+        ...card,
+        blockUuid: currentBlock.items[0].BlockUuid,
+        header: currentBlock.items[0].ItemHeader,
+        text: currentBlock.items[0].ItemText,
+      })
+    }
   }, [getCurrentBlockFromUrl().items[0].ItemHeader, getCurrentBlockFromUrl().items[0].ItemText])
 
   const toggleMode = () => {
@@ -176,6 +196,7 @@ export default function Details(props) {
           data-testid="details-list-item"
           key={item.BlockUuid}
           href={`/details/${block}/${item.BlockUuid}`}
+          onClick={handleItemChange}
         >
           {item.ItemHeader}
         </ListGroup.Item>

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -25,7 +25,7 @@ export default function Details(props) {
   const handleItemChange = event => {
     event.preventDefault()
     const href = event.target.getAttribute('href')
-    props.history.replace(href)
+    props.history.push(href)
     const selectedItemBlockUuid = href.slice(href.lastIndexOf('/') + 1)
     const currentBlock = getCurrentBlockFromUrl()
     const card = currentBlock.items.findIndex(item => {
@@ -61,8 +61,7 @@ export default function Details(props) {
   }
 
   useEffect(() => {
-    const currentBlock = getCurrentBlockFromUrl()
-    props.history.push(currentBlock.block)
+    props.history.push(props.match.url)
     if (props.listResponse.length === 0) props.getCanvasData()
   }, [])
 
@@ -75,7 +74,7 @@ export default function Details(props) {
         header: currentBlock.items[0].ItemHeader,
         text: currentBlock.items[0].ItemText,
       })
-      props.history.push(`${currentBlock.items[0].BlockUuid}`)
+      props.history.push(props.match.url)
     }
   }, [
     getCurrentBlockFromUrl().items[0].ItemHeader,

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -25,6 +25,7 @@ export default function Details(props) {
   const handleItemChange = event => {
     event.preventDefault()
     const href = event.target.getAttribute('href')
+    props.history.replace(href)
     const selectedItemBlockUuid = href.slice(href.lastIndexOf('/') + 1)
     const currentBlock = getCurrentBlockFromUrl()
     const card = currentBlock.items.findIndex(item => {
@@ -60,6 +61,8 @@ export default function Details(props) {
   }
 
   useEffect(() => {
+    const currentBlock = getCurrentBlockFromUrl()
+    props.history.push(currentBlock.block)
     if (props.listResponse.length === 0) props.getCanvasData()
   }, [])
 
@@ -72,8 +75,13 @@ export default function Details(props) {
         header: currentBlock.items[0].ItemHeader,
         text: currentBlock.items[0].ItemText,
       })
+      props.history.push(`${currentBlock.items[0].BlockUuid}`)
     }
-  }, [getCurrentBlockFromUrl().items[0].ItemHeader, getCurrentBlockFromUrl().items[0].ItemText])
+  }, [
+    getCurrentBlockFromUrl().items[0].ItemHeader,
+    getCurrentBlockFromUrl().items[0].ItemText,
+    getCurrentBlockFromUrl().items.length,
+  ])
 
   const toggleMode = () => {
     setWriteMode(!writeMode)
@@ -103,7 +111,7 @@ export default function Details(props) {
       },
       queryStringParameters: {
         Team: 'Team Continuous',
-        BlockUuid: getCurrentBlockFromUrl().items[0].BlockUuid,
+        BlockUuid: card.blockUuid,
       },
     }).then(() => {
       props.getCanvasData()
@@ -187,15 +195,15 @@ export default function Details(props) {
 
   const listItems = () => {
     const block = getCurrentBlockFromUrl()
-      .block.replace(' ', '-')
-      .toLowerCase()
-    const list = getCurrentBlockFromUrl().items.map(item => {
+    const blockKebabCased = block.block.replace(' ', '-').toLowerCase()
+    const list = block.items.map((item, index) => {
       return (
         <ListGroup.Item
           action
+          active={index === 0 && card.blockUuid === block.items[0].BlockUuid}
           data-testid="details-list-item"
           key={item.BlockUuid}
-          href={`/details/${block}/${item.BlockUuid}`}
+          href={`/details/${blockKebabCased}/${item.BlockUuid}`}
           onClick={handleItemChange}
         >
           {item.ItemHeader}
@@ -203,7 +211,7 @@ export default function Details(props) {
       )
     })
 
-    if (getCurrentBlockFromUrl().items[0] !== undefined) {
+    if (block.items[0] !== undefined) {
       return (
         <div className="details-list">
           <ListGroup>{list}</ListGroup>

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -55,26 +55,46 @@ export default function Details(props) {
     }
 
     if (foundBlock.items.length === 0) {
-      foundBlock.items = [{ ItemHeader: '', ItemText: '' }]
+      foundBlock.items = [{ ItemHeader: '', ItemText: '', BlockUuid: '' }]
     }
     return foundBlock ? foundBlock : emptyBlock
   }
 
   useEffect(() => {
-    props.history.push(props.match.url)
     if (props.listResponse.length === 0) props.getCanvasData()
   }, [])
 
   useEffect(() => {
-    if (card.blockUuid === '') {
-      const currentBlock = getCurrentBlockFromUrl()
+    const currentBlock = getCurrentBlockFromUrl()
+    if (props.match.url.includes(currentBlock.block)) {
+      const selectedItemBlockUuid = props.match.url.slice(props.match.url.lastIndexOf('/') + 1)
+      const card = currentBlock.items.findIndex(item => {
+        return item.BlockUuid === selectedItemBlockUuid
+      })
+
+      if (card === -1) {
+        setCard({
+          ...card,
+          blockUuid: currentBlock.items[0].BlockUuid,
+          header: currentBlock.items[0].ItemHeader,
+          text: currentBlock.items[0].ItemText,
+        })
+      } else {
+        setCard({
+          ...card,
+          blockUuid: currentBlock.items[card].BlockUuid,
+          header: currentBlock.items[card].ItemHeader,
+          text: currentBlock.items[card].ItemText,
+        })
+      }
+    } else {
+      props.history.push(props.match.url + '/' + currentBlock.items[0].BlockUuid)
       setCard({
         ...card,
         blockUuid: currentBlock.items[0].BlockUuid,
         header: currentBlock.items[0].ItemHeader,
         text: currentBlock.items[0].ItemText,
       })
-      props.history.push(props.match.url)
     }
   }, [
     getCurrentBlockFromUrl().items[0].ItemHeader,
@@ -95,7 +115,7 @@ export default function Details(props) {
       },
       queryStringParameters: {
         Team: 'Team Continuous',
-        BlockUuid: getCurrentBlockFromUrl().items[0].BlockUuid,
+        BlockUuid: card.blockUuid,
       },
     }).then(() => {
       props.getCanvasData()
@@ -199,7 +219,7 @@ export default function Details(props) {
       return (
         <ListGroup.Item
           action
-          active={index === 0 && card.blockUuid === block.items[0].BlockUuid}
+          active={card.blockUuid === item.BlockUuid}
           data-testid="details-list-item"
           key={item.BlockUuid}
           href={`/details/${blockKebabCased}/${item.BlockUuid}`}

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -27,7 +27,7 @@ export default function Details(props) {
     const href = event.target.getAttribute('href')
     props.history.push(href)
     const selectedItemBlockUuid = href.slice(href.lastIndexOf('/') + 1)
-    const currentBlock = getCurrentBlockFromUrl()
+    const currentBlock = getCurrentBlock()
     const card = currentBlock.items.findIndex(item => {
       return item.BlockUuid === selectedItemBlockUuid
     })
@@ -39,11 +39,11 @@ export default function Details(props) {
     setWriteMode(false)
   }
 
-  const getCurrentBlockFromUrl = () => {
+  const getCurrentBlock = () => {
     const emptyBlock = {
       block: '',
       blockDescription: '',
-      items: [{ ItemHeader: '', ItemText: '', BlockUuid: '' }],
+      items: [{ BlockUuid: '', ItemHeader: '', ItemText: '' }],
     }
 
     const foundBlock = props.listResponse.find(({ block }) => {
@@ -56,7 +56,7 @@ export default function Details(props) {
     }
 
     if (foundBlock.items.length === 0) {
-      foundBlock.items = [{ ItemHeader: '', ItemText: '', BlockUuid: '' }]
+      foundBlock.items = [{ BlockUuid: '', ItemHeader: '', ItemText: '' }]
     }
     return foundBlock ? foundBlock : emptyBlock
   }
@@ -66,7 +66,7 @@ export default function Details(props) {
   }, [])
 
   useEffect(() => {
-    const currentBlock = getCurrentBlockFromUrl()
+    const currentBlock = getCurrentBlock()
     if (props.match.url.includes(currentBlock.block)) {
       const selectedItemBlockUuid = props.match.url.slice(props.match.url.lastIndexOf('/') + 1)
       const card = currentBlock.items.findIndex(item => {
@@ -98,9 +98,9 @@ export default function Details(props) {
       })
     }
   }, [
-    getCurrentBlockFromUrl().items[0].ItemHeader,
-    getCurrentBlockFromUrl().items[0].ItemText,
-    getCurrentBlockFromUrl().items.length,
+    getCurrentBlock().items[0].ItemHeader,
+    getCurrentBlock().items[0].ItemText,
+    getCurrentBlock().items.length,
   ])
 
   const toggleMode = () => {
@@ -184,7 +184,7 @@ export default function Details(props) {
           </div>
         </Fragment>
       )
-    } else if (getCurrentBlockFromUrl().items[0] !== undefined) {
+    } else if (getCurrentBlock().items[0] !== undefined) {
       return (
         <div className="details-card" data-testid="details-readmode">
           <div className="details-card-container">
@@ -215,9 +215,9 @@ export default function Details(props) {
   }
 
   const listItems = () => {
-    const block = getCurrentBlockFromUrl()
+    const block = getCurrentBlock()
     const blockKebabCased = block.block.replace(' ', '-').toLowerCase()
-    const list = block.items.map((item, index) => {
+    const list = block.items.map(item => {
       return (
         <ListGroup.Item
           action
@@ -245,7 +245,7 @@ export default function Details(props) {
     <div>
       <div className="details-container">
         <div className="details-form">
-          <div className="details-block">{getCurrentBlockFromUrl().block}</div>
+          <div className="details-block">{getCurrentBlock().block}</div>
           <div className="details-create">
             <Link to="/item/create" data-testid="createItemButton">
               <i className="fa fa-plus" /> Create item

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -135,6 +135,7 @@ export default function Details(props) {
     }).then(() => {
       props.getCanvasData()
       toggleMode()
+      props.history.push(props.match.url.slice(0, props.match.url.lastIndexOf('/')))
     })
   }
 


### PR DESCRIPTION
## This adds the following functionality
**Select specific items in the Details component**
 - When viewing an item on the Details view, the url is updated with the corresponding BlockUuid.
 - If you load the Details component with a specific BlockUuid on the url, then the component will display the contents of the item with the corresponding BlockUuid.
 - If you load the Details component without any specific BlockUuid on the url, then the component will display the first item in the list.
- If you are editing an item, and click a different item in the list (i.e. when you're in the "write mode"), then you will leave the "write mode" and view the contents of the item you clicked.

**Delete a selected item**
 - When an item has been deleted, the Details component will re-render and display the first item in the list of items.

I also fixed the `can delete an item` e2e test in details.js, as well as added an e2e test for selecting items.

I've also done some light refactoring where `getCurrentBlockFromUrl()` was repeated over and over, and I replaced that with storing the result from getCurrentBlockFromUrl() into a variable and access that variable several times instead. 

## Known issues
 - The Details component is not re-rendered when using the browser's [Back] button after navigating through a few items.