### PR TITLE
Fix/details mobile view

### DIFF
--- a/src/components/details/Details.css
+++ b/src/components/details/Details.css
@@ -81,7 +81,7 @@
   padding-left: 0;
   padding-right: 0;
   width: 100%;
-  grid-template-rows: min-content min-content min-content min-content;
+  grid-template-rows: minmax(48px, 1fr) min-content min-content min-content;
   grid-template-columns: minmax(0px, 1fr) minmax(0px, 1fr) minmax(150px, 3fr) minmax(100px, 1fr);
 }
 
@@ -98,14 +98,10 @@
   padding-top: 10px;
 }
 
-.details-card-read-text {
-  min-height: 100px;
-  max-height: 250px;
-}
-
 .details-card-write-text {
   min-height: 100px;
   max-height: 250px;
+  margin-right: 12px;
 }
 
 .details-create a:hover {
@@ -128,6 +124,8 @@
 }
 
 .details-card-read-text {
+  min-height: 100px;
+  max-height: 200px;
   border-radius: 4px;
   border: solid 1px;
   margin-left: 6px;

--- a/src/components/details/Details.css
+++ b/src/components/details/Details.css
@@ -2,42 +2,174 @@
   .details-container .btn {
     font-size: 0.9rem;
   }
+
+  .details-form {
+    display: grid;
+    border: 2px solid;
+    gap: 5px;
+    padding-bottom: 10px;
+    padding-left: 0;
+    padding-right: 0;
+    width: 100%;
+    grid-template-rows: min-content min-content min-content min-content;
+    grid-template-columns: minmax(0px, 1fr) minmax(0px, 1fr) minmax(150px, 3fr) minmax(100px, 1fr);
+    grid-template-areas:
+      'block . . create'
+      'list list list list'
+      'card card card card'
+      'delete cancel submit .';
+  }
+
+  .details-create {
+    grid-area: create;
+    justify-self: end;
+    margin-right: 12px;
+    margin-top: 2px;
+  }
+
+  .details-list {
+    grid-area: list;
+    max-height: 168px;
+    overflow: scroll;
+    padding-left: 10px;
+    padding-right: 10px;
+    text-align: left;
+  }
+
+  .details-card-read-header {
+    border-radius: 4px;
+    border: solid 1px;
+    margin-top: 10px;
+    margin-left: 6px;
+    padding-left: 12px;
+    margin-right: 12px;
+    text-align: left;
+    height: 39px;
+    line-height: 37px;
+  }
+
+  .details-card-read-text {
+    border-radius: 4px;
+    border: solid 1px;
+    min-height: 100px;
+    max-height: 250px;
+    overflow: scroll;
+    margin-left: 6px;
+    margin-top: 16px;
+    padding-top: 5px;
+    padding-left: 12px;
+    margin-right: 12px;
+    text-align: left;
+
+    background: linear-gradient(white 0%, rgba(255, 255, 255, 0)),
+      linear-gradient(rgba(255, 255, 255, 0), white 0%) 0 100%,
+      radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0)),
+      radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0)) 0 100%;
+
+    background-repeat: no-repeat;
+    background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+
+    /* Opera doesn't support this in the shorthand */
+    background-attachment: local, local, scroll, scroll;
+  }
+
+  .details-block {
+    grid-area: block;
+    grid-column-end: create;
+    padding-left: 10px;
+    text-align: left;
+    font-size: 17pt;
+  }
+
+  .details-create-cancel-buttons {
+    grid-area: submit;
+    justify-self: end;
+    margin-right: 12px;
+  }
+
+  .details-submit {
+    grid-area: submit;
+    text-align: right;
+    margin-right: 12px;
+  }
 }
 
-.details-container {
-  height: 10px;
-  padding-top: 10px;
-}
+@media (min-width: 411px) {
+  .details-container {
+    height: 10px;
+    padding-top: 10px;
+  }
 
-.details-form {
-  display: grid;
-  border: 2px solid;
-  gap: 5px;
-  padding-bottom: 10px;
-  padding-left: 0;
-  padding-right: 0;
-  width: 100%;
-  grid-template-rows: min-content min-content min-content min-content;
-  grid-template-columns: minmax(0px, 1fr) minmax(0px, 1fr) minmax(150px, 3fr) minmax(100px, 1fr);
-  grid-template-areas:
-    'block empty empty create'
-    'card card card list'
-    'delete cancel submit list';
-}
+  .details-form {
+    display: grid;
+    border: 2px solid;
+    gap: 5px;
+    padding-bottom: 10px;
+    padding-left: 0;
+    padding-right: 0;
+    width: 100%;
+    grid-template-rows: min-content min-content min-content min-content;
+    grid-template-columns: minmax(0px, 1fr) minmax(0px, 1fr) minmax(150px, 3fr) minmax(100px, 1fr);
+    grid-template-areas:
+      'block empty empty create'
+      'card card card list'
+      'delete cancel submit list';
+  }
 
-.details-block {
-  grid-area: block;
-  grid-column-end: create;
-  padding-left: 10px;
-  text-align: left;
-  font-size: 17pt;
-}
+  .details-create {
+    grid-area: create;
+    margin-left: 12px;
+    padding-top: 10px;
+    padding-right: 10px;
+  }
 
-.details-create {
-  grid-area: create;
-  margin-left: 12px;
-  padding-top: 10px;
-  padding-right: 10px;
+  .details-list {
+    grid-area: list;
+    padding-top: 65px;
+    padding-left: 10px;
+    padding-right: 10px;
+    text-align: left;
+  }
+  .details-card-read-header {
+    border-radius: 4px;
+    border: solid 1px;
+    margin-top: 10px;
+    margin-left: 6px;
+    padding-left: 12px;
+    text-align: left;
+    height: 39px;
+    line-height: 37px;
+  }
+
+  .details-card-read-text {
+    border-radius: 4px;
+    border: solid 1px;
+    min-height: 100px;
+    max-height: 250px;
+    margin-left: 6px;
+    margin-top: 16px;
+    padding-top: 5px;
+    padding-left: 12px;
+    text-align: left;
+  }
+
+  .details-block {
+    grid-area: block;
+    grid-column-end: create;
+    padding-left: 10px;
+    text-align: left;
+    font-size: 17pt;
+  }
+
+  .details-create-cancel-buttons {
+    grid-area: submit;
+    justify-self: end;
+  }
+
+  .details-submit {
+    grid-area: submit;
+    text-align: right;
+  }
 }
 
 .details-create a:hover {
@@ -57,28 +189,6 @@
   padding-left: 6px;
 }
 
-.details-card-read-header {
-  border-radius: 4px;
-  border: solid 1px;
-  margin-top: 10px;
-  margin-left: 6px;
-  padding-left: 12px;
-  text-align: left;
-  height: 39px;
-  line-height: 37px;
-}
-
-.details-card-read-text {
-  border-radius: 4px;
-  height: 373px;
-  border: solid 1px;
-  margin-left: 6px;
-  margin-top: 16px;
-  padding-top: 5px;
-  padding-left: 12px;
-  text-align: left;
-}
-
 .details-delete {
   grid-area: delete;
   padding-left: 12px;
@@ -86,24 +196,6 @@
 }
 
 .details-cancel {
-  text-align: left;
-}
-
-.details-create-cancel-buttons {
-  grid-area: submit;
-  justify-self: end;
-}
-
-.details-submit {
-  grid-area: submit;
-  text-align: right;
-}
-
-.details-list {
-  grid-area: list;
-  padding-top: 65px;
-  padding-left: 10px;
-  padding-right: 10px;
   text-align: left;
 }
 

--- a/src/components/details/Details.css
+++ b/src/components/details/Details.css
@@ -6,13 +6,13 @@
 .details-form {
   display: grid;
   border: 2px solid;
-  grid-gap: 5px;
+  gap: 5px;
   padding-bottom: 10px;
   padding-left: 0;
   padding-right: 0;
-  width: 70%;
-  grid-template-rows: 30px 35px 400px 35px;
-  grid-template-columns: 1fr 3fr 105px 170px;
+  width: 100%;
+  grid-template-rows: 1fr 1fr 8fr 1fr;
+  grid-template-columns: 1fr 3fr 1fr 1fr;
   grid-template-areas:
     'block create create create'
     'card card card list'

--- a/src/components/details/Details.css
+++ b/src/components/details/Details.css
@@ -1,3 +1,9 @@
+@media (max-width: 410px) {
+  .details-container .btn {
+    font-size: 0.9rem;
+  }
+}
+
 .details-container {
   height: 10px;
   padding-top: 10px;
@@ -11,11 +17,10 @@
   padding-left: 0;
   padding-right: 0;
   width: 100%;
-  grid-template-rows: 1fr 1fr 8fr 1fr;
-  grid-template-columns: 1fr 3fr 1fr 1fr;
+  grid-template-rows: min-content min-content min-content min-content;
+  grid-template-columns: minmax(0px, 1fr) minmax(0px, 1fr) minmax(150px, 3fr) minmax(100px, 1fr);
   grid-template-areas:
-    'block create create create'
-    'card card card list'
+    'block empty empty create'
     'card card card list'
     'delete cancel submit list';
 }
@@ -30,7 +35,7 @@
 
 .details-create {
   grid-area: create;
-  text-align: right;
+  margin-left: 12px;
   padding-top: 10px;
   padding-right: 10px;
 }
@@ -53,7 +58,6 @@
 }
 
 .details-card-read-header {
-  grid-area: header;
   border-radius: 4px;
   border: solid 1px;
   margin-top: 10px;
@@ -65,7 +69,6 @@
 }
 
 .details-card-read-text {
-  grid-area: text;
   border-radius: 4px;
   height: 373px;
   border: solid 1px;
@@ -78,19 +81,21 @@
 
 .details-delete {
   grid-area: delete;
-  padding-left: 10px;
+  padding-left: 12px;
   text-align: left;
 }
 
 .details-cancel {
-  grid-area: cancel;
-  padding-right: 10px;
-  text-align: right;
+  text-align: left;
+}
+
+.details-create-cancel-buttons {
+  grid-area: submit;
+  justify-self: end;
 }
 
 .details-submit {
   grid-area: submit;
-  padding-right: 10px;
   text-align: right;
 }
 
@@ -106,7 +111,6 @@
   border: solid 1px;
   padding-top: 10px;
   padding-left: 10px;
-  text-align: left;
 }
 
 .details-new-list-item {

--- a/src/components/details/Details.css
+++ b/src/components/details/Details.css
@@ -4,15 +4,6 @@
   }
 
   .details-form {
-    display: grid;
-    border: 2px solid;
-    gap: 5px;
-    padding-bottom: 10px;
-    padding-left: 0;
-    padding-right: 0;
-    width: 100%;
-    grid-template-rows: min-content min-content min-content min-content;
-    grid-template-columns: minmax(0px, 1fr) minmax(0px, 1fr) minmax(150px, 3fr) minmax(100px, 1fr);
     grid-template-areas:
       'block . . create'
       'list list list list'
@@ -21,46 +12,25 @@
   }
 
   .details-create {
-    grid-area: create;
     justify-self: end;
     margin-right: 12px;
     margin-top: 2px;
   }
 
   .details-list {
-    grid-area: list;
     max-height: 168px;
     overflow: scroll;
-    padding-left: 10px;
-    padding-right: 10px;
-    text-align: left;
   }
 
   .details-card-read-header {
-    border-radius: 4px;
-    border: solid 1px;
-    margin-top: 10px;
-    margin-left: 6px;
-    padding-left: 12px;
     margin-right: 12px;
-    text-align: left;
-    height: 39px;
-    line-height: 37px;
   }
 
   .details-card-read-text {
-    border-radius: 4px;
-    border: solid 1px;
-    min-height: 100px;
-    max-height: 250px;
     overflow: scroll;
-    margin-left: 6px;
-    margin-top: 16px;
-    padding-top: 5px;
-    padding-left: 12px;
     margin-right: 12px;
-    text-align: left;
 
+    /* Add shadows to show scrollable content */
     background: linear-gradient(white 0%, rgba(255, 255, 255, 0)),
       linear-gradient(rgba(255, 255, 255, 0), white 0%) 0 100%,
       radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0)),
@@ -73,103 +43,69 @@
     background-attachment: local, local, scroll, scroll;
   }
 
-  .details-block {
-    grid-area: block;
-    grid-column-end: create;
-    padding-left: 10px;
-    text-align: left;
-    font-size: 17pt;
-  }
-
   .details-create-cancel-buttons {
-    grid-area: submit;
-    justify-self: end;
     margin-right: 12px;
   }
 
   .details-submit {
-    grid-area: submit;
-    text-align: right;
     margin-right: 12px;
   }
 }
 
 @media (min-width: 411px) {
-  .details-container {
-    height: 10px;
-    padding-top: 10px;
-  }
-
   .details-form {
-    display: grid;
-    border: 2px solid;
-    gap: 5px;
-    padding-bottom: 10px;
-    padding-left: 0;
-    padding-right: 0;
-    width: 100%;
-    grid-template-rows: min-content min-content min-content min-content;
-    grid-template-columns: minmax(0px, 1fr) minmax(0px, 1fr) minmax(150px, 3fr) minmax(100px, 1fr);
     grid-template-areas:
-      'block empty empty create'
+      'block . . create'
       'card card card list'
       'delete cancel submit list';
   }
 
   .details-create {
-    grid-area: create;
     margin-left: 12px;
     padding-top: 10px;
     padding-right: 10px;
   }
 
   .details-list {
-    grid-area: list;
     padding-top: 65px;
-    padding-left: 10px;
-    padding-right: 10px;
-    text-align: left;
   }
-  .details-card-read-header {
-    border-radius: 4px;
-    border: solid 1px;
-    margin-top: 10px;
-    margin-left: 6px;
-    padding-left: 12px;
-    text-align: left;
-    height: 39px;
-    line-height: 37px;
-  }
+}
 
-  .details-card-read-text {
-    border-radius: 4px;
-    border: solid 1px;
-    min-height: 100px;
-    max-height: 250px;
-    margin-left: 6px;
-    margin-top: 16px;
-    padding-top: 5px;
-    padding-left: 12px;
-    text-align: left;
-  }
+/* Common CSS (applicable to any viewport) */
 
-  .details-block {
-    grid-area: block;
-    grid-column-end: create;
-    padding-left: 10px;
-    text-align: left;
-    font-size: 17pt;
-  }
+.details-form {
+  display: grid;
+  border: 2px solid;
+  gap: 5px;
+  padding-bottom: 10px;
+  padding-left: 0;
+  padding-right: 0;
+  width: 100%;
+  grid-template-rows: min-content min-content min-content min-content;
+  grid-template-columns: minmax(0px, 1fr) minmax(0px, 1fr) minmax(150px, 3fr) minmax(100px, 1fr);
+}
 
-  .details-create-cancel-buttons {
-    grid-area: submit;
-    justify-self: end;
-  }
+.details-block {
+  grid-area: block;
+  grid-column-end: create;
+  padding-left: 10px;
+  text-align: left;
+  font-size: 17pt;
+}
 
-  .details-submit {
-    grid-area: submit;
-    text-align: right;
-  }
+.details-container {
+  height: 10px;
+  padding-top: 10px;
+}
+
+.details-card-read-text {
+  min-height: 100px;
+  max-height: 250px;
+}
+
+.details-card-write-text {
+  min-height: 100px;
+  max-height: 250px;
 }
 
 .details-create a:hover {
@@ -178,6 +114,27 @@
 
 .details-card {
   grid-area: card;
+}
+
+.details-card-read-header {
+  border-radius: 4px;
+  border: solid 1px;
+  margin-top: 10px;
+  margin-left: 6px;
+  padding-left: 12px;
+  text-align: left;
+  height: 39px;
+  line-height: 37px;
+}
+
+.details-card-read-text {
+  border-radius: 4px;
+  border: solid 1px;
+  margin-left: 6px;
+  margin-top: 16px;
+  padding-top: 5px;
+  padding-left: 12px;
+  text-align: left;
 }
 
 .details-card-container {
@@ -189,6 +146,21 @@
   padding-left: 6px;
 }
 
+.details-list {
+  grid-area: list;
+  padding-left: 10px;
+  padding-right: 10px;
+  text-align: left;
+}
+
+.details-create-cancel-buttons {
+  grid-area: submit;
+  justify-self: end;
+}
+.details-create {
+  grid-area: create;
+}
+
 .details-delete {
   grid-area: delete;
   padding-left: 12px;
@@ -197,6 +169,11 @@
 
 .details-cancel {
   text-align: left;
+}
+
+.details-submit {
+  grid-area: submit;
+  text-align: right;
 }
 
 .details-list-item {

--- a/src/components/details/Details.css
+++ b/src/components/details/Details.css
@@ -8,7 +8,7 @@
       'block . . create'
       'list list list list'
       'card card card card'
-      'delete cancel submit .';
+      'delete cancel submit submit';
   }
 
   .details-create {

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -245,7 +245,7 @@ export default function Details(props) {
               <Form.Group>
                 <Form.Control
                   as="textarea"
-                  rows="15"
+                  rows="7"
                   data-testid="details-updateform-text"
                   onChange={handleTextChange}
                   placeholder="Enter some details..."
@@ -277,10 +277,11 @@ export default function Details(props) {
                   defaultValue={card.header}
                 />
               </Form.Group>
-              <Form.Group>
+              <Form.Group className="details-card-write-text">
                 <Form.Control
+                  className="details-card-write-text"
                   as="textarea"
-                  rows="15"
+                  rows="7"
                   autoFocus
                   data-testid="details-updateform-text"
                   onChange={handleTextChange}

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -336,9 +336,9 @@ export default function Details(props) {
     })
 
     return list.length > 0 ? (
-      <div className="details-list" data-testid="details-list">
-        <ListGroup>{list}</ListGroup>
-      </div>
+      <ListGroup className="details-list" data-testid="details-list">
+        {list}
+      </ListGroup>
     ) : null
   }
 

--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -254,12 +254,10 @@ export default function Details(props) {
             </Form>
           </div>
         </div>
-        <div className="details-cancel">
+        <div className="details-create-cancel-buttons">
           <Button variant="secondary" onClick={handleCreateCancel}>
             Cancel
           </Button>
-        </div>
-        <div className="details-submit">
           <Button variant="success" onClick={handleCreate}>
             Create
           </Button>
@@ -297,12 +295,10 @@ export default function Details(props) {
             Delete
           </Button>
         </div>
-        <div className="details-cancel">
+        <div className="details-create-cancel-buttons">
           <Button variant="secondary" onClick={handleEditCancel}>
             Cancel
           </Button>
-        </div>
-        <div className="details-submit">
           <Button variant="success" onClick={handleUpdate}>
             Update
           </Button>


### PR DESCRIPTION
Fixes #63.

## Summary
Mostly CSS changes. Some minor changes in `<Details/>` component as well as light refactoring.

### Adds two media queries
- `max-width: 410px` for CSS used on "mobile"
- `min-width: 411px` for CSS on everything larger than "mobile"

### Changes to how the `<Details/>` component is displayed in mobile
- The list of items is displayed above the form 
- The items list is scrollable when there are more than 3 items
- The description of the current selected item is scrollable when the height exceeds 200px

### Other minor fixes
- The first grid row is always at least 48px high, so reserve space for the [Add Item]. This will keep the grid height consistent regardless if the [Add Item] button is displayed or not
- In Create/Edit mode: Change the numbers of "rows" from `15` to `7`, because it's better in mobile and the change doesn't really have a big impact on desktop. The `textarea` is still resizable by the user